### PR TITLE
Always return a value from client.turn_off

### DIFF
--- a/pyharmony/client.py
+++ b/pyharmony/client.py
@@ -166,10 +166,9 @@ class HarmonyClient(sleekxmpp.ClientXMPP):
         """
         activity = self.get_current_activity()
         if activity != -1:
-            if self.start_activity(-1):
-                return True
-            else:
-                return False
+            return self.start_activity(-1)
+        else:
+            return true
 
 
 def create_and_connect_client(ip_address, port, token):


### PR DESCRIPTION
In HomeAssistant I get `ERROR (Thread-5) [pyharmony.__main__] Power Off failed` when harmony is already off. This is due to the fact that nothing is returned from `client.turn_off` if the system is already off.