### PR TITLE
Pass activity_callback when creating a client

### DIFF
--- a/pyharmony/__main__.py
+++ b/pyharmony/__main__.py
@@ -38,7 +38,7 @@ def get_client(ip, port, activity_callback=None):
         object: Authenticated client instance.
     """
 
-    client = harmony_client.create_and_connect_client(ip, port)
+    client = harmony_client.create_and_connect_client(ip, port, activity_callback)
     return client
 
 


### PR DESCRIPTION
It seems that this change was accidentally dropped when merging with the token removal commit.

As a workaround, I can call `register_activity_callback` on the returned `client` myself so you do not need to push a new release just for this change.