### PR TITLE
Simplify callback activityId regex

### DIFF
--- a/pyharmony/client.py
+++ b/pyharmony/client.py
@@ -205,7 +205,7 @@ class HarmonyClient(sleekxmpp.ClientXMPP):
     def register_activity_callback(self, activity_callback):
         """Register a callback that is executed on activity changes."""
         def hub_event(xml):
-            match = re.match('activityId=(-?\d+).*errorCode=200', xml.get_payload()[0].text)
+            match = re.search('activityId=(-?\d+)', xml.get_payload()[0].text)
             activity_id = match.group(1)
             if activity_id is not None:
                 activity_callback(int(activity_id))


### PR DESCRIPTION
After some testing, I am afraid that we will need another release after all.

The Hub returns a string like this:

  errorCode=200:errorString=OK:activityId=18635065

and it turns out that different firmware versions do not use the same
order of those fields. This commit simplifies the matching to just the
minimum that is needed, hopefully making it resilient to future changes.