### PR TITLE
Write command name, not action name

### DIFF
--- a/pyharmony/__main__.py
+++ b/pyharmony/__main__.py
@@ -96,7 +96,8 @@ def ha_write_config_file(config, path):
             file_out.write('  ' + device['id'] + ' - ' + device['label'] + '\n')
             for controlGroup in device['controlGroup']:
                 for function in controlGroup['function']:
-                    file_out.write('    ' + function['name'] + '\n')
+                    action = json.loads(function['action'])
+                    file_out.write('    ' + action['command'] + '\n')
     return True
 
 


### PR DESCRIPTION
This addresses an issue reported in home-assistant/home-assistant#11482.

It seems that `ha_write_config_file` is writing command names that do not always work with `send_command`.

For example, I have these three commands (though I am not sure how it ended up like that):
```
{"action":"{\"command\":\"2\",\"type\":\"IRCommand\",\"deviceId\":\"33791407\"}","name":"Number2","label":"2"}

{"action":"{\"command\":\"PowerToggle\",\"type\":\"IRCommand\",\"deviceId\":\"33791407\"}","name":"PowerToggle","label":"Power Toggle"}

{"action":"{\"command\":\"Power Off\",\"type\":\"IRCommand\",\"deviceId\":\"43002980\"}","name":"PowerOff","label":"Power Off"}
```

Neither `name` nor `label` works for all of these. However, decoding the JSON in `action` and picking out `command` seems to work in all cases. So here is a PR that does that.

I did not investigate the meaning of these fields so I am quite open to my change also being wrong.